### PR TITLE
feat: add searxng web search service

### DIFF
--- a/docker-compose.ai-agent.yaml
+++ b/docker-compose.ai-agent.yaml
@@ -37,6 +37,18 @@ services:
     labels:
       <<: *ddev-common-ai-agent-labels
 
+  searxng:
+    container_name: ddev-${DDEV_SITENAME}-searxng
+    image: searxng/searxng:latest
+    restart: unless-stopped
+    environment:
+      - SEARXNG_BIND_ADDRESS=0.0.0.0:8080
+      - SEARXNG_SECRET_KEY=${SEARXNG_SECRET_KEY:-localdev-searxng-secret}
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    labels:
+      <<: *ddev-common-ai-agent-labels
+
 volumes:
   n8n_data: {}
   supabase_db_data: {}

--- a/install.yaml
+++ b/install.yaml
@@ -2,5 +2,6 @@ name: ai-agent
 
 project_files:
   - docker-compose.ai-agent.yaml
+  - searxng/settings.yml
 
 ddev_version_constraint: '>= v1.24.3'

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,13 @@
+#ddev-generated
+# see https://docs.searxng.org/admin/settings/settings.html#settings-use-default-settings
+use_default_settings: true
+server:
+  secret_key: "${SEARXNG_SECRET_KEY}"
+  limiter: false
+  image_proxy: true
+ui:
+  static_use_hash: true
+search:
+  formats:
+    - html
+    - json

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -53,6 +53,12 @@ health_checks() {
 
   run curl -sfI https://${PROJNAME}.ddev.site:5678
   assert_output --partial "HTTP/2 200"
+  run ddev exec -s web sh -lc '
+    curl -sS -o /tmp/searxng_test.json -w "%{http_code}" \
+      "http://searxng:8080/search?q=test&format=json"
+  '
+  assert_success
+  assert_output "200"
 }
 
 teardown() {


### PR DESCRIPTION
Closes #4.

## The Issue

- Fixes #4

Need a way to perform a web search from a workflow.

## How This PR Solves The Issue

Provides the SearXNG service with sensible defaults like JSON format support.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/jcandan/ddev-ai-agent/tarball/refs/pull/5/head
ddev restart
```

## Automated Testing Overview

Provides a health check against the JSON formatted search request.

## Release/Deployment Notes

Should be able to be adopted simply with `ddev add-on get ddev-ai-agent && ddev restart`