### PR TITLE
feat: add optional ollama service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ Install and start using DDEV.
 
 Access **n8n** at `https://<project>.ddev.site:5678`
 
+### Optional local LLM (Ollama)
+
+This add-on can optionally start a local Ollama LLM service using a DDEV profile.
+
+Start the stack with the `ollama` profile:
+
+```bash
+ddev start --profiles ollama
+```
+
+From other services in the stack (for example, n8n), you can reach the local LLM
+at:
+
+http://ollama:11434
+
+Use that URL as the base for your Ollama / OpenAI-compatible nodes in n8n when
+the profile is enabled.
+
+You can check the service connection with:
+
+```bash
+ddev exec curl http://ollama:11434/api/version
+```
+
+The service will be picked up by subsequent `ddev restart`, but to stop the
+`ollama` service, run `ddev stop` and `ddev start` again without the profile.
+
 ## Roadmap
 
 See [Roadmap](https://github.com/jcandan/ddev-ai-agent/wiki/Roadmap) for details

--- a/docker-compose.ai-agent.yaml
+++ b/docker-compose.ai-agent.yaml
@@ -7,7 +7,7 @@ services:
   n8n:
     container_name: ddev-${DDEV_SITENAME}-n8n
     image: n8nio/n8n:latest
-    restart: unless-stopped
+    restart: no
     environment:
       - N8N_HOST=${DDEV_HOSTNAME}
       - N8N_PORT=5678
@@ -27,7 +27,7 @@ services:
   supabase-db:
     container_name: ddev-${DDEV_SITENAME}-supabase-db
     image: supabase/postgres:15.1.0.104
-    restart: unless-stopped
+    restart: no
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
@@ -40,7 +40,7 @@ services:
   searxng:
     container_name: ddev-${DDEV_SITENAME}-searxng
     image: searxng/searxng:latest
-    restart: unless-stopped
+    restart: no
     environment:
       - SEARXNG_BIND_ADDRESS=0.0.0.0:8080
       - SEARXNG_SECRET_KEY=${SEARXNG_SECRET_KEY:-localdev-searxng-secret}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -13,14 +13,6 @@ services:
     environment:
       # Keep the model server warm for a while between requests.
       - OLLAMA_KEEP_ALIVE=24h
-    # Explicit readiness signal for DDEV / Docker:
-    healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-      start_interval: 5s
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -1,0 +1,23 @@
+#ddev-generated
+services:
+  ollama:
+    container_name: ddev-${DDEV_SITENAME}-ollama
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    profiles:
+      - ollama
+    volumes:
+      # Persist models per project.
+      - ollama_data:/root/.ollama
+    environment:
+      # Keep the model server warm for a while between requests.
+      - OLLAMA_KEEP_ALIVE=24h
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+      com.ddev.platform: docker
+      com.ddev.type: service
+      com.ddev.service: ollama
+
+volumes:
+  ollama_data: {}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -13,6 +13,14 @@ services:
     environment:
       # Keep the model server warm for a while between requests.
       - OLLAMA_KEEP_ALIVE=24h
+    # Explicit readiness signal for DDEV / Docker:
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      # ~2 minutes max
+      retries: 12
+      start_period: 20s
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-ollama
     image: ollama/ollama:latest
     restart: unless-stopped
+    # Only start this when explicitly requested.
     profiles:
       - ollama
     volumes:
@@ -15,9 +16,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-      com.ddev.platform: docker
-      com.ddev.type: service
-      com.ddev.service: ollama
 
 volumes:
   ollama_data: {}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -3,7 +3,7 @@ services:
   ollama:
     container_name: ddev-${DDEV_SITENAME}-ollama
     image: ollama/ollama:latest
-    restart: unless-stopped
+    restart: no
     # Only start this when explicitly requested.
     profiles:
       - ollama

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -16,11 +16,11 @@ services:
     # Explicit readiness signal for DDEV / Docker:
     healthcheck:
       test: ["CMD", "ollama", "list"]
-      interval: 10s
-      timeout: 5s
-      # ~2 minutes max
-      retries: 12
-      start_period: 20s
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+      start_interval: 5s
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -13,9 +13,6 @@ services:
     environment:
       # Keep the model server warm for a while between requests.
       - OLLAMA_KEEP_ALIVE=24h
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
 
 volumes:
   ollama_data: {}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -13,6 +13,9 @@ services:
     environment:
       # Keep the model server warm for a while between requests.
       - OLLAMA_KEEP_ALIVE=24h
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
 
 volumes:
   ollama_data: {}

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: ai-agent
 
 project_files:
   - docker-compose.ai-agent.yaml
+  - docker-compose.ollama.yaml
   - searxng/settings.yml
 
 ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,6 +75,7 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
+  ddev debug test
   run ddev start -y --profiles=ollama
   assert_success
   health_checks

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,6 +76,7 @@ teardown() {
   run ddev add-on get "${DIR}"
   assert_success
   ddev utility composer-config
+  echo "# output: $output" >&3
   run ddev start -y --profiles=ollama
   ddev logs ollama
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,10 +75,8 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
-  ddev utility composer-config
-  echo "# output: $output" >&3
   run ddev start -y --profiles=ollama
-  ddev logs ollama
+  echo "# output: $output" >&3
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,7 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
-  run ddev start -v -y --profiles=ollama
+  run ddev start -y --profiles=ollama
   assert_success
   health_checks
 }
@@ -86,7 +86,7 @@ teardown() {
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success
-  run ddev start -v -y --profiles=ollama
+  run ddev start -y --profiles=ollama
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,8 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
-  ddev debug test
+  ddev utility composer-config
+  ddev logs ollama
   run ddev start -y --profiles=ollama
   assert_success
   health_checks

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,8 +76,8 @@ teardown() {
   run ddev add-on get "${DIR}"
   assert_success
   ddev utility composer-config
-  ddev logs ollama
   run ddev start -y --profiles=ollama
+  ddev logs ollama
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,7 +76,6 @@ teardown() {
   run ddev add-on get "${DIR}"
   assert_success
   run ddev start -y --profiles=ollama
-  echo "# output: $output" >&3
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,7 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
-  run ddev start -y --profiles ollama
+  run ddev start -y --profiles=ollama
   assert_success
   health_checks
 }
@@ -86,7 +86,7 @@ teardown() {
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success
-  run ddev start -y --profiles ollama
+  run ddev start -y --profiles=ollama
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -88,6 +88,8 @@ teardown() {
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success
+  run ddev restart -y
+  assert_success
   run ddev start -y --profiles=ollama
   assert_success
   health_checks

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,7 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
-  run ddev start -y --profiles=ollama
+  run ddev start -v -y --profiles=ollama
   assert_success
   health_checks
 }
@@ -86,7 +86,7 @@ teardown() {
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success
-  run ddev start -y --profiles=ollama
+  run ddev start -v -y --profiles=ollama
   assert_success
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,6 +75,8 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
+  run ddev restart -y
+  assert_success
   run ddev start -y --profiles=ollama
   assert_success
   health_checks


### PR DESCRIPTION
Closes #8.

## The Issue

- Fixes #8 

Add an LLM service.

## How This PR Solves The Issue

Adds an Ollama service via DDEV optional profiles.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/jcandan/ddev-ai-agent/tarball/refs/pull/9/head
ddev start --profiles ollama
ddev exec curl http://ollama:11434/api/version
```

## Automated Testing Overview

Ensures tests start with the `ollama` profile and runs a health check on the service.
