### PR TITLE
feat: add ai db service

### DIFF
--- a/docker-compose.ai-agent.yaml
+++ b/docker-compose.ai-agent.yaml
@@ -24,16 +24,16 @@ services:
     labels:
       <<: *ddev-common-ai-agent-labels
 
-  supabase-db:
-    container_name: ddev-${DDEV_SITENAME}-supabase-db
-    image: supabase/postgres:15.1.0.104
+  ai-db:
+    container_name: ddev-${DDEV_SITENAME}-ai-db
+    image: postgres:16
     restart: no
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
     volumes:
-      - supabase_db_data:/var/lib/postgresql/data
+      - ai_db_data:/var/lib/postgresql/data
     labels:
       <<: *ddev-common-ai-agent-labels
 
@@ -51,4 +51,4 @@ services:
 
 volumes:
   n8n_data: {}
-  supabase_db_data: {}
+  ai_db_data: {}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -43,6 +43,12 @@ health_checks() {
   run curl -sfI https://${PROJNAME}.ddev.site:5678
   assert_output --partial "HTTP/2 200"
 
+  run ddev exec -s ai-db sh -lc '
+    pg_isready -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+  '
+  assert_success
+  assert_output --partial "accepting connections"
+
   # SearXNG JSON search should return HTTP 200.
   run ddev exec -s web sh -lc '
     curl -sS -w "%{http_code}" "http://searxng:8080/search?q=test&format=json" -o /dev/null


### PR DESCRIPTION
## The Issue

- Fixes #17 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Deletes the supabase db and adds the postgres db service.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/jcandan/ddev-ai-agent/tarball/refs/pull/22/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Removes the supabase service. Adds a postgres service as `ai-db`.