### PR TITLE
feat!: change ai-db for pgvector postgres

### DIFF
--- a/ai-db/init/01-enable-pgvector.sql
+++ b/ai-db/init/01-enable-pgvector.sql
@@ -1,0 +1,4 @@
+-- #ddev-generated
+-- Enable pgvector extension for the default database.
+-- This only creates the extension, no tables.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/docker-compose.ai-agent.yaml
+++ b/docker-compose.ai-agent.yaml
@@ -26,7 +26,7 @@ services:
 
   ai-db:
     container_name: ddev-${DDEV_SITENAME}-ai-db
-    image: postgres:16
+    image: pgvector/pgvector:pg16
     restart: no
     environment:
       - POSTGRES_PASSWORD=postgres
@@ -34,6 +34,7 @@ services:
       - POSTGRES_DB=postgres
     volumes:
       - ai_db_data:/var/lib/postgresql/data
+      - ./ai-db/init:/docker-entrypoint-initdb.d
     labels:
       <<: *ddev-common-ai-agent-labels
 

--- a/install.yaml
+++ b/install.yaml
@@ -4,5 +4,7 @@ project_files:
   - docker-compose.ai-agent.yaml
   - docker-compose.ollama.yaml
   - searxng/settings.yml
+  - ai-db/init/01-enable-pgvector.sql
+
 
 ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -43,11 +43,17 @@ health_checks() {
   run curl -sfI https://${PROJNAME}.ddev.site:5678
   assert_output --partial "HTTP/2 200"
 
+  # ai-db Postgres should be accepting connections.
   run ddev exec -s ai-db sh -lc '
     pg_isready -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB"
   '
   assert_success
   assert_output --partial "accepting connections"
+
+  # pgvector extension should be installed in ai-db.
+  run ddev exec -s ai-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT 1 FROM pg_extension WHERE extname = '\''vector'\''"'
+  assert_success
+  assert_output "1"
 
   # SearXNG JSON search should return HTTP 200.
   run ddev exec -s web sh -lc '


### PR DESCRIPTION
Closes #18.

## The Issue

- Fixes #18

Need vector extension for our AI database service.

## How This PR Solves The Issue

Switches to the pgvector image.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/jcandan/ddev-ai-agent/tarball/refs/pull/27/head
ddev restart
```

## Automated Testing Overview

Checks that the extension is enabled.
