### PR TITLE
ci: fix pre-release bump on breaking bang

### DIFF
--- a/.github/workflows/release-on-push-release-branch.yml
+++ b/.github/workflows/release-on-push-release-branch.yml
@@ -90,7 +90,7 @@ jobs:
 
           # Bump just the pre-release identifier:
           # e.g. 1.0.0-alpha.3 -> 1.0.0-alpha.4
-          custom_release_rules: "feat:prerelease,fix:prerelease,breaking:prerelease"
+          custom_release_rules: "feat:prerelease,fix:prerelease,*!:prerelease,breaking:prerelease"
 
       - name: Create GitHub pre-release with generated notes
         if: ${{ steps.tag_version.outputs.new_tag != '' }}


### PR DESCRIPTION
Closes #28.

## The Issue

- Fixes #28

Breaking change commits with `feat!:` commit type do not fire a pre-release bump.

## How This PR Solves The Issue

`feat!:` ends up being parsed as `type = feat!`, and not as a breaking `feat`. That’s exactly what’s described in this [Stack Overflow](https://stackoverflow.com/questions/70781241/semantic-release-breaking-change-using-exclamation-mark) example where `feat!:` results in “no release” until a custom rule is added. 

Semantic-release has a known workaround: you match type: `*!`